### PR TITLE
chore(env): add examples for el/cl endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,23 @@ SSV_OPERATOR_ID=123
 # If both SSV_OPERATOR_ID and SSV_OPERATOR_IDS are present then SSV_OPERATOR_IDS has priority
 # SSV_OPERATOR_IDS=123,456
 
+# Execution client json-rpc endpoint
+EXECUTION_ENDPOINT=http://localhost:8545
+# Execution client connection timeout
+EXECUTION_TIMEOUT=30
+# Execution client retry connection timeout
+EXECUTION_RETRY_TIMEOUT=60
+
+# Consensus client http endpoint
+CONSENSUS_ENDPOINT=http://localhost:5052
+# Consensus client connection timeout
+CONSENSUS_TIMEOUT=30
+# Consensus client retry connection timeout
+CONSENSUS_RETRY_TIMEOUT=60
+
+# Path to database
+DATABASE=dvt-operator-sidecar.db
+
 ###########################
 # Remote signer section
 ###########################


### PR DESCRIPTION
In the latest release were added new several env variables, so I added them to the `.env.example`